### PR TITLE
Gp fix kubeconfig

### DIFF
--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -40,7 +40,7 @@ def kubernetes_client() -> BatchV1Api:
     """
     returns a kubernetes client
     """
-    config.load_kube_config()
+    config.load_config()
     return BatchV1Api()
 
 

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -81,7 +81,7 @@ def get_container_and_volumes(container):
         mount_path = volume['mountPath']
         name = volume['name']
         mount_volumes.append(V1VolumeMount(mount_path=mount_path, name=name))
-        volumes.append(V1Volume(name=name, host_path='/mnt'))
+        volumes.append(V1Volume(name=name, host_path=V1HostPathVolumeSource(path='/mnt')))
     container['volume_mounts'] = mount_volumes
     return container, volumes
 

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -124,7 +124,7 @@ def is_pod_running(pod: V1PodSpec):
 
 
 def corev1_client():
-    config.load_kube_config()
+    config.load_config()
     core_v1 = CoreV1Api()
     return core_v1
 

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -17,7 +17,8 @@ from kubernetes.client import (
     V1Pod,
     V1PodCondition,
     V1Volume,
-    V1VolumeMount
+    V1VolumeMount,
+    V1HostPathVolumeSource
 )
 from kubernetes.client.api.core_v1_api import CoreV1Api
 from kubernetes.client.api_client import ApiClient
@@ -70,13 +71,15 @@ def add_mount_volumes(container):
     """
     Returns a container with V1VolumeMount objects from the spec schema of a container
     """
-    volumes = container['mount_volumes']
+    volumes_spec = container['volume_mounts']
     mount_volumes = []
-    for volume in volumes:
+    volumes=[]
+    for volume in volumes_spec:
         mount_path = volume['mountPath']
         name = volume['name']
         mount_volumes.append(V1VolumeMount(mount_path=mount_path, name=name))
-    container['mount_volumes'] = mount_volumes
+        volumes.append(V1Volume(name=name,host_path=V1HostPathVolumeSource(path='/mnt')))
+    container['volume_mounts'] = mount_volumes
     return container
 
 

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -58,10 +58,10 @@ def pod_spec_from_dict(
     for container in spec_schema["containers"]:
         if "imagePullPolicy" in container:
             container["image_pull_policy"] = container.pop("imagePullPolicy")
-        if  container['volume_mounts']:
+        if "volume_mounts" in container and container['volume_mounts']:
             container, container_volumes = get_container_and_volumes(container)
             volumes.append(container_volumes)
-            containers.append(V1Container(**container))
+        containers.append(V1Container(**container))
     pod_template = V1PodTemplateSpec(
         metadata=V1ObjectMeta(name=name, labels=labels),
         spec=V1PodSpec(restart_policy=restartPolicy, containers=containers, volumes=volumes),

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -80,8 +80,9 @@ def get_container_and_volumes(container):
     for volume in volumes_spec:
         mount_path = volume['mountPath']
         name = volume['name']
+        host_path = volume['host_path']
         mount_volumes.append(V1VolumeMount(mount_path=mount_path, name=name))
-        volumes.append(V1Volume(name=name, host_path=V1HostPathVolumeSource(path='/mnt')))
+        volumes.append(V1Volume(name=name, host_path=V1HostPathVolumeSource(path=host_path)))
     container['volume_mounts'] = mount_volumes
     return container, volumes
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ class PyTest(TestCommand):
         sys.exit(pytest.main(self.test_args))
 
 
-version = '1.0.1'
+version = '1.0.2'
 
 setup(name='kubeluigi',
       version=version,

--- a/test/kubernetes_helpers_test.py
+++ b/test/kubernetes_helpers_test.py
@@ -36,10 +36,12 @@ def test_pod_spec_from_dict():
     assert pod_spec.metadata.name == "name_of_pod"
     assert pod_spec.metadata.labels == labels
     assert pod_spec.spec.restart_policy == "Never"
-    container = pod_spec.spec.containers[0]
-    assert container.name == dummy_pod_spec["containers"][0]["name"]
-    assert container.image == dummy_pod_spec["containers"][0]["image"]
-    assert container.env == dummy_pod_spec["containers"][0]["env"]
+    t = pod_spec.spec.containers
+    print("poo")
+    # container = pod_spec.spec.containers[0]
+    # assert container.name == dummy_pod_spec["containers"][0]["name"]
+    # assert container.image == dummy_pod_spec["containers"][0]["image"]
+    # assert container.env == dummy_pod_spec["containers"][0]["env"]
 
 
 def test_job_definition():

--- a/test/kubernetes_helpers_test.py
+++ b/test/kubernetes_helpers_test.py
@@ -36,12 +36,10 @@ def test_pod_spec_from_dict():
     assert pod_spec.metadata.name == "name_of_pod"
     assert pod_spec.metadata.labels == labels
     assert pod_spec.spec.restart_policy == "Never"
-    t = pod_spec.spec.containers
-    print("poo")
-    # container = pod_spec.spec.containers[0]
-    # assert container.name == dummy_pod_spec["containers"][0]["name"]
-    # assert container.image == dummy_pod_spec["containers"][0]["image"]
-    # assert container.env == dummy_pod_spec["containers"][0]["env"]
+    container = pod_spec.spec.containers[0]
+    assert container.name == dummy_pod_spec["containers"][0]["name"]
+    assert container.image == dummy_pod_spec["containers"][0]["image"]
+    assert container.env == dummy_pod_spec["containers"][0]["env"]
 
 
 def test_job_definition():


### PR DESCRIPTION
This PR deals with two main things:

Loading the config, which now uses load_config which contains the logic to deal with both local and Kubernetes environments 

and 

Adding and mounting volumes is fixed to use new classes V1Volumes and V1VolumeMounts. This solves the errors for jobs failing when he couldn't find the volumes