### PR TITLE
Fixing terminate state bug

### DIFF
--- a/kubeluigi/__init__.py
+++ b/kubeluigi/__init__.py
@@ -15,6 +15,7 @@ logger = logging.getLogger("luigi-interface")
 
 
 class KubernetesJobTask:
+    
     def _init_kubernetes(self):
         self.__logger = logger
         self.kubernetes_client = kubernetes_client()

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -256,6 +256,12 @@ def has_job_started(job: V1Job) -> bool:
                             job=job,
                             message=f"Job: {job.metadata.name} - Pod: {pod.metadata.name} container has a  weird status : {status}",
                         )
+                if status.state.terminated:
+                    if status.state.terminated.reason == 'Error':
+                        raise FailedJob(
+                            job=job,
+                            message=f"Job: {job.metadata.name} - Pod: {pod.metadata.name} container has run with an error : {status}",
+                        )
         if pod.status.conditions:
             for cond in pod.status.conditions:
                 logger.info(f"{logs_prefix} pod condition {cond}")

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -159,12 +159,13 @@ def print_pod_logs(job: V1Job, pod: V1PodSpec):
     """
     logs_prefix = "JOB: " + job.metadata.name + " POD: " + pod.metadata.name
     while True:
-        logger.info(logs_prefix + " ...waiting for POD to start")
-        sleep(DEFAULT_POLL_INTERVAL)
         try:
             if is_pod_running(pod):
                 logger.info(logs_prefix + " POD is running")
                 break
+            else:
+                logger.info(logs_prefix + " ...waiting for POD to start")
+                sleep(DEFAULT_POLL_INTERVAL)
         except ApiException as e:
             logger.warning("error while fetching pod logs :" + logs_prefix)
             logger.exception(e)
@@ -336,6 +337,16 @@ def clean_job_resources(k8s_client: ApiClient, job: V1Job) -> None:
     delete kubernetes resources associated to a Job
     """
     logger.info(f"JOB: {job.metadata.name} - Cleaning Job's resources")
+
+    # Try to print pod logs before cleaning up
+    logger.info("Trying to get Pod logs before cleaning up...")
+    pods = get_job_pods(job)
+    for pod in pods:
+        try:
+            print_pod_logs(job, pod)
+        except Exception as e:
+            logger.warning("no logs for POD: {pod.metadata.name}: {e}")
+    
     api_response = k8s_client.delete_namespaced_job(
         name=job.metadata.name,
         namespace=job.metadata.namespace,

--- a/kubeluigi/k8s.py
+++ b/kubeluigi/k8s.py
@@ -261,7 +261,7 @@ def has_job_started(job: V1Job) -> bool:
                     if status.state.terminated.reason == 'Error':
                         raise FailedJob(
                             job=job,
-                            message=f"Job: {job.metadata.name} - Pod: {pod.metadata.name} container has run with an error : {status}",
+                            message=f"Job: {job.metadata.name} - Pod: {pod.metadata.name} container has run with an error. Please check container logs",
                         )
         if pod.status.conditions:
             for cond in pod.status.conditions:

--- a/test/kubernetes_helpers_test.py
+++ b/test/kubernetes_helpers_test.py
@@ -204,22 +204,23 @@ def test_has_scaling_failed():
         type="something",
     )
     assert not has_scaling_failed(condition)
-    
 
 
 @patch("kubeluigi.k8s.get_job_pods")
-def test_has_job_started_pod_is_failed(mocked_get_job_pods):
-    # a pod associated  with the job is in a failed state
-    failed_pod = MagicMock()
-    failed_pod_status = MagicMock()
-    failed_pod_status.status.state.terminated = True
-    failed_pod.status.container_statuses = [failed_pod_status]
-    mocked_get_job_pods.return_value = [failed_pod]
+def test_has_job_started_pod_is_terminated(mocked_get_job_pods):
+    """
+    A pod which is terminated is a pod that has started running.
+    Terminated does not entail a failed job/pod.
+    """
+    pod = MagicMock()
+    pod_status = MagicMock()
+    pod_status.status.state.terminated = True
+    pod.status.container_statuses = [pod_status]
+    mocked_get_job_pods.return_value = [pod_status]
     labels = {"l1": "label1"}
     pod = pod_spec_from_dict("name_of_pod", dummy_pod_spec, labels=labels)
     job = job_definition("my_job", "my_uiid", 100, pod, labels, "my_namespace")
-    with pytest.raises(FailedJob):
-        has_job_started(job)
+    assert has_job_started(job)
 
 
 @patch("kubeluigi.k8s.get_job_pods")


### PR DESCRIPTION
# Relevant change:
`has_job_started` used to work such that if a pod state was `terminated` it would raise a `FailedJob` exception. However this is no true. A pod can be terminated and be either successful or failed.

Logic now is such that a `terminated` state would imply that the task has started. It is up to the following  function down the road  (i.e: `is_job_completed` ) to figure out whether the terminated task has failed or not.

Added a unit test for this.

## Thiago: But why did this affected me?

I ran your Unirec task and it runs ok after this change. 

Why was it affecting you?
I think the pod started running and got terminated before the `has_job_started` logic would take effect. Meaning by the time `has_job_started` would run it would find that the pod was terminated, trigger a `FailedJob` and clean up. All of this took place super quickly.

## other changes

`DEFAULT_POLL_INTERVAL=2` adding a lower poll interval so that we can see logs for jobs that run quicker. It is just some nits.

I added a code block to try to print pod logs before clean up. Thinking that this would help clear out whether pod ran but an error took place, or if there was an error somewhere else.