### PR TITLE
Gp failed submit

### DIFF
--- a/kubeluigi/__init__.py
+++ b/kubeluigi/__init__.py
@@ -102,9 +102,8 @@ class KubernetesJobTask:
         self.__logger.info("Submitting Kubernetes Job: " + self.uu_name)
         try:
             run_and_track_job(self.kubernetes_client, job)
-        except Exception as e:
-            logger.warning("Luigi has failed to submit the job")
-            raise e
+        except:
+            logger.warning("Luigi has failed to submit the job, starting cleaning")
         finally:
             clean_job_resources(self.kubernetes_client, job)
 

--- a/kubeluigi/__init__.py
+++ b/kubeluigi/__init__.py
@@ -102,6 +102,9 @@ class KubernetesJobTask:
         self.__logger.info("Submitting Kubernetes Job: " + self.uu_name)
         try:
             run_and_track_job(self.kubernetes_client, job)
+        except Exception as e:
+            logger.warning("Luigi has failed to submit the job")
+            raise e
         finally:
             clean_job_resources(self.kubernetes_client, job)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ class PyTest(TestCommand):
         sys.exit(pytest.main(self.test_args))
 
 
-version = '1.0.4'
+version = '1.0.5'
 
 setup(name='kubeluigi',
       version=version,


### PR DESCRIPTION
This just adds a warning message when a job fails to submit. The error is raised by the clean process but it is a little unclear in the logs that the submit failed without this message. 