### PR TITLE
Isolating a task to job function

### DIFF
--- a/kubeluigi/__init__.py
+++ b/kubeluigi/__init__.py
@@ -85,8 +85,7 @@ class KubernetesJobTask:
         """
         raise NotImplementedError("subclass must define spec_schema")
 
-    def run(self):
-        self._init_kubernetes()
+    def build_job_definition(self):
         pod_template_spec = pod_spec_from_dict(
             self.uu_name, self.spec_schema, self.restart_policy, self.labels
         )
@@ -99,6 +98,11 @@ class KubernetesJobTask:
             labels=self.labels,
             namespace=self.namespace,
         )
+        return job
+        
+    def run(self):
+        self._init_kubernetes()
+        job = self.build_job_definition()
         self.__logger.info("Submitting Kubernetes Job: " + self.uu_name)
         try:
             run_and_track_job(self.kubernetes_client, job)


### PR DESCRIPTION
## Why do we need this PR?

Sometimes it is useful to check how a task matches to a kubectl yaml resource. By exposing this function in isolation we can then better debug when thigns are not working as expected