### PR TITLE
Exporting job as yaml

### DIFF
--- a/kubeluigi/__init__.py
+++ b/kubeluigi/__init__.py
@@ -85,8 +85,7 @@ class KubernetesJobTask:
         """
         raise NotImplementedError("subclass must define spec_schema")
 
-    def run(self):
-        self._init_kubernetes()
+    def build_job_definition(self):
         pod_template_spec = pod_spec_from_dict(
             self.uu_name, self.spec_schema, self.restart_policy, self.labels
         )
@@ -99,6 +98,11 @@ class KubernetesJobTask:
             labels=self.labels,
             namespace=self.namespace,
         )
+        return job
+        
+    def run(self):
+        self._init_kubernetes()
+        job = self.build_job_definition()
         self.__logger.info("Submitting Kubernetes Job: " + self.uu_name)
         try:
             run_and_track_job(self.kubernetes_client, job)

--- a/test/test_kubernetes_job_task.py
+++ b/test/test_kubernetes_job_task.py
@@ -1,0 +1,49 @@
+import yaml
+
+from kubeluigi import KubernetesJobTask
+
+
+class DummyTask(KubernetesJobTask):
+
+    @property
+    def name(self):
+        return "my_dummy_task"
+
+    @property
+    def spec_schema(self):
+        return {
+            "containers": [{
+                "name": self.name,
+                "image": "my_container:my_tag",
+                "command": "dummy_cmd"
+            }],
+        }
+
+    @property
+    def namespace(self):
+        return "some_namespace"
+
+    
+def test_job_definition():
+    """
+    testing we generate a valid job definition
+    """
+    task = DummyTask()
+    k8s_job_definition = task.build_job_definition()
+    assert(k8s_job_definition.api_version == "batch/v1")
+    assert(k8s_job_definition.kind == "Job")
+    assert(k8s_job_definition.spec.template.spec.containers[0].command == "dummy_cmd")
+
+    
+def test_job_definition_as_yaml():
+    """
+    testing that we can generate a compliant k8s yaml file
+    equivalent to our task
+    """
+    task = DummyTask()
+    yaml_task_definition = task.as_yaml()
+    yaml_as_dict = yaml.safe_load(yaml_task_definition)
+    assert(yaml_as_dict['apiVersion'] == "batch/v1")
+    assert(yaml_as_dict['kind'] == "Job")
+    assert(yaml_as_dict['spec']['template']['spec']['containers'][0]['command'] == "dummy_cmd")
+    assert(yaml_as_dict['spec']['template']['spec']['volumes'] == [])


### PR DESCRIPTION
## Why do we need this PR?

It let us export jobs as yaml to see what is actually getting run on k8s

## What has changed here?
- added the function `build_job_definition` which returns a k8s job definition. This logic is now separated from `execute`